### PR TITLE
Update for Elixir 1.5 compatibility

### DIFF
--- a/lib/ex_unit_notifier.ex
+++ b/lib/ex_unit_notifier.ex
@@ -8,7 +8,7 @@ defmodule ExUnitNotifier do
 
   """
 
-  use GenEvent
+  use GenServer
 
   alias ExUnitNotifier.Counter
   alias ExUnitNotifier.MessageFormatter
@@ -21,17 +21,17 @@ defmodule ExUnitNotifier do
 
   def init(_opts), do: {:ok, %Counter{}}
 
-  def handle_event({:test_finished, %ExUnit.Test{state: nil}}, counter), do: {:ok, counter |> Counter.add_test}
-  def handle_event({:test_finished, %ExUnit.Test{state: {:failed, _}}}, counter), do: {:ok, counter |> Counter.add_test |> Counter.add_failed}
-  def handle_event({:test_finished, %ExUnit.Test{state: {:skip, _}}}, counter), do: {:ok, counter |> Counter.add_test |> Counter.add_skipped}
-  def handle_event({:test_finished, %ExUnit.Test{state: {:invalid, _}}}, counter), do: {:ok, counter |> Counter.add_test |> Counter.add_invalid}
+  def handle_cast({:test_finished, %ExUnit.Test{state: nil}}, counter), do: {:noreply, counter |> Counter.add_test}
+  def handle_cast({:test_finished, %ExUnit.Test{state: {:failed, _}}}, counter), do: {:noreply, counter |> Counter.add_test |> Counter.add_failed}
+  def handle_cast({:test_finished, %ExUnit.Test{state: {:skip, _}}}, counter), do: {:noreply, counter |> Counter.add_test |> Counter.add_skipped}
+  def handle_cast({:test_finished, %ExUnit.Test{state: {:invalid, _}}}, counter), do: {:noreply, counter |> Counter.add_test |> Counter.add_invalid}
 
-  def handle_event({:suite_finished, run_us, load_us}, counter) do
+  def handle_cast({:suite_finished, run_us, load_us}, counter) do
     notifier().notify status(counter), MessageFormatter.format(counter, run_us, load_us)
-    :remove_handler
+    {:noreply, counter}
   end
 
-  def handle_event(_, counter), do: {:ok, counter}
+  def handle_cast(_, counter), do: {:noreply, counter}
 
   defp status(%Counter{failures: failures, invalid: invalid}) when failures > 0 or invalid > 0, do: :error
   defp status(_), do: :ok

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule ExUnitNotifier.Mixfile do
      source_url: "https://github.com/navinpeiris/ex_unit_notifier",
      homepage_url: "https://github.com/navinpeiris/ex_unit_notifier",
      package: package(),
-     elixir: "~> 1.2",
+     elixir: "~> 1.4",
      elixirc_paths: elixirc_paths(Mix.env),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
Elixir 1.5 has deprecated the use of GenEvent for ExUnit handlers, causing warnings to be printed when running test suites.