### PR TITLE
adding clear history opt config to notify-send

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ config :ex_unit_notifier, notifier: ExUnitNotifier.Notifiers.TerminalNotifier
 
 You can use one of the available notifiers found in [lib/ex_unit_notifier/notifiers](lib/ex_unit_notifier/notifiers), or you can write your own.
 
+## Notification Options
+
+For `notify-send` users, it is possible to clear the notifications from notifications center history using the following configuration, defaults to `false`:
+
+```elixir
+config :ex_unit_notifier, clear_history: true
+```
+
 ### License
 
 The MIT License

--- a/lib/ex_unit_notifier.ex
+++ b/lib/ex_unit_notifier.ex
@@ -37,7 +37,12 @@ defmodule ExUnitNotifier do
     do: {:noreply, counter |> Counter.add_test() |> Counter.add_invalid()}
 
   def handle_cast({:suite_finished, run_us, load_us}, counter) do
-    notifier().notify(status(counter), MessageFormatter.format(counter, run_us, load_us))
+    apply(notifier(), :notify, [
+      status(counter),
+      MessageFormatter.format(counter, run_us, load_us),
+      opts()
+    ])
+
     {:noreply, counter}
   end
 
@@ -47,6 +52,11 @@ defmodule ExUnitNotifier do
     do: :error
 
   defp status(_), do: :ok
+
+  defp opts,
+    do: %{
+      clear_history: Application.get_env(:ex_unit_notifier, :clear_history, false)
+    }
 
   defp notifier, do: Application.get_env(:ex_unit_notifier, :notifier, first_available_notifier())
 

--- a/lib/ex_unit_notifier/notifiers/notify_send.ex
+++ b/lib/ex_unit_notifier/notifiers/notify_send.ex
@@ -1,18 +1,29 @@
 defmodule ExUnitNotifier.Notifiers.NotifySend do
   @moduledoc false
 
-  def notify(status, message) do
-    System.cmd(executable(), [
-      "--app-name=ExUnit",
-      "--icon=#{get_icon(status)}",
-      "ExUnit",
-      message
-    ])
+  def notify(status, message, opts) do
+    System.cmd(executable(), build_args(status, message, opts))
   end
 
   def available?, do: executable() != nil
 
   defp executable, do: System.find_executable("notify-send")
+
+  defp build_args(status, message, %{clear_history: clear_history}) do
+    args = [
+      "--app-name=ExUnit",
+      "--icon=#{get_icon(status)}",
+      "ExUnit",
+      message
+    ]
+
+    maybe_add_clear_history(args, clear_history)
+  end
+
+  defp maybe_add_clear_history(args, true),
+    do: List.insert_at(args, 2, "--hint=int:transient:1")
+
+  defp maybe_add_clear_history(args, _clear_history), do: args
 
   defp get_icon(status),
     do: Application.app_dir(:ex_unit_notifier, "priv/icons/#{status |> Atom.to_string()}.png")

--- a/lib/ex_unit_notifier/notifiers/terminal_notifier.ex
+++ b/lib/ex_unit_notifier/notifiers/terminal_notifier.ex
@@ -1,7 +1,7 @@
 defmodule ExUnitNotifier.Notifiers.TerminalNotifier do
   @moduledoc false
 
-  def notify(status, message) do
+  def notify(status, message, _opts) do
     System.cmd(executable(), [
       "-group",
       "ex-unit-notifier",

--- a/lib/ex_unit_notifier/notifiers/terminal_title.ex
+++ b/lib/ex_unit_notifier/notifiers/terminal_title.ex
@@ -1,7 +1,7 @@
 defmodule ExUnitNotifier.Notifiers.TerminalTitle do
   @moduledoc false
 
-  def notify(_status, message), do: IO.puts(:stderr, "\e]2;ExUnit - #{message} \a")
+  def notify(_status, message, _opts), do: IO.puts(:stderr, "\e]2;ExUnit - #{message} \a")
 
   def available?, do: true
 end

--- a/test/ex_unit_notifier_test.exs
+++ b/test/ex_unit_notifier_test.exs
@@ -3,7 +3,7 @@ defmodule ExUnitNotifierTest do
   doctest ExUnitNotifier
 
   defmodule TestNotifier do
-    def notify(status, message) do
+    def notify(status, message, _opts) do
       send(test_pid(), {status, message})
     end
 


### PR DESCRIPTION
As a linux user, it is kinda annoying having all test notifications flooding the notification center. This PR adds a `clear_history` application config for `notify-send` notifier.