### PR TITLE
Add handle_cast which supports Elixir version 1.12.0 and above

### DIFF
--- a/lib/ex_unit_notifier.ex
+++ b/lib/ex_unit_notifier.ex
@@ -36,7 +36,19 @@ defmodule ExUnitNotifier do
   def handle_cast({:test_finished, %ExUnit.Test{state: {:invalid, _}}}, counter),
     do: {:noreply, counter |> Counter.add_test() |> Counter.add_invalid()}
 
+  # Elixir version < 1.12.0
   def handle_cast({:suite_finished, run_us, load_us}, counter) do
+    apply(notifier(), :notify, [
+      status(counter),
+      MessageFormatter.format(counter, run_us, load_us),
+      opts()
+    ])
+
+    {:noreply, counter}
+  end
+
+  # Elixir version >= 1.12.0, see https://hexdocs.pm/ex_unit/1.12.0/ExUnit.Formatter.html
+  def handle_cast({:suite_finished, %{run: run_us, async: _async_us, load: load_us}}, counter) do
     apply(notifier(), :notify, [
       status(counter),
       MessageFormatter.format(counter, run_us, load_us),


### PR DESCRIPTION
In elixir version 1.12 and above, the time values of the :suite_finished event has changed. This PR supports it.
see. https://hexdocs.pm/ex_unit/1.12.0/ExUnit.Formatter.html

Thank you