### PR TITLE
Add tmux notifier

### DIFF
--- a/lib/ex_unit_notifier/notifiers/tmux_notifier.ex
+++ b/lib/ex_unit_notifier/notifiers/tmux_notifier.ex
@@ -1,0 +1,22 @@
+defmodule ExUnitNotifier.Notifiers.TmuxNotifier do
+  @moduledoc false
+
+  def notify(status, _message, _opts) do
+    pane = System.get_env("TMUX_PANE")
+
+    if pane do
+      # tmux set-window-option -t"$TMUX_PANE" window-status-style bg=red
+      System.cmd("tmux", ["set-window-option", "-t#{pane}", "window-status-style", style(status)])
+    end
+  end
+
+  def available?, do: true
+
+  defp style(status) do
+    if status == :error do
+      "bg=red"
+    else
+      "bg=green"
+    end
+  end
+end


### PR DESCRIPTION
Hello!

I've added a new notifier. This allows me to run a test watcher in one tmux pane (2), while editing code in another (3).

The pane's background changes to red upon failure, back to green upon success.

![image](https://user-images.githubusercontent.com/1557738/189044810-af7c994e-07f8-4e89-9156-d89f3d1898df.png)
